### PR TITLE
fix: update royalty scores and add Royal Flush bonus

### DIFF
--- a/lib/features/game/domain/hand_evaluator.dart
+++ b/lib/features/game/domain/hand_evaluator.dart
@@ -823,7 +823,8 @@ class HandEvaluator {
 
     // High card: Joker becomes Ace
     // Sort ranks with jokers as Aces (14)
-    final allRanks = [...ranks, ...List.filled(jokers, 14)]..sort((a, b) => b - a);
+    final allRanks = [...ranks, ...List.filled(jokers, 14)]
+      ..sort((a, b) => b - a);
     return Hand3Rank(Hand3Category.highCard, allRanks.take(3).toList(),
         isWild: true);
   }

--- a/lib/features/game/domain/ruleset.dart
+++ b/lib/features/game/domain/ruleset.dart
@@ -11,32 +11,37 @@ class Ruleset {
   int royaltyTop(Hand3Rank r) {
     if (r.category == Hand3Category.threeOfAKind) {
       final rank = r.tiebreakers.first;
-      // 222:+7, 333:+8, ..., KKK:+18, AAA:+22 (docsの例/ベースライン)
+      // 222:+10, 333:+11, ..., KKK:+21, AAA:+22
       if (rank == 14) return 22; // AAA
       return switch (rank) {
-        2 => 7,
-        3 => 8,
-        4 => 9,
-        5 => 10,
-        6 => 11,
-        7 => 12,
-        8 => 13,
-        9 => 14,
-        10 => 15,
-        11 => 16,
-        12 => 17,
-        13 => 18,
+        2 => 10,
+        3 => 11,
+        4 => 12,
+        5 => 13,
+        6 => 14,
+        7 => 15,
+        8 => 16,
+        9 => 17,
+        10 => 18,
+        11 => 19,
+        12 => 20,
+        13 => 21,
         _ => 0,
       };
     }
     if (r.category == Hand3Category.pair) {
       final pair = r.tiebreakers.first;
-      if (pair >= 6 && pair <= 10) return 1; // 66–TT
+      // 66:+1, 77:+2, 88:+3, 99:+4, TT:+5, JJ:+6, QQ:+7, KK:+8, AA:+9
       return switch (pair) {
-        11 => 2, // JJ
-        12 => 3, // QQ
-        13 => 4, // KK
-        14 => 5, // AA
+        6 => 1,
+        7 => 2,
+        8 => 3,
+        9 => 4,
+        10 => 5,
+        11 => 6,
+        12 => 7,
+        13 => 8,
+        14 => 9,
         _ => 0,
       };
     }
@@ -44,95 +49,31 @@ class Ruleset {
   }
 
   int royaltyMiddle(Hand5Rank r) {
+    if (r.category == Hand5Category.straightFlush) {
+      // Royal Flush (Ace-high straight flush) = 50, otherwise 30
+      return (r.tiebreakers.isNotEmpty && r.tiebreakers[0] == 14) ? 50 : 30;
+    }
     return switch (r.category) {
       Hand5Category.threeOfAKind => 2,
       Hand5Category.straight => 4,
       Hand5Category.flush => 8,
       Hand5Category.fullHouse => 12,
       Hand5Category.fourOfAKind => 20,
-      Hand5Category.straightFlush => 30,
       _ => 0,
     };
   }
 
   int royaltyBottom(Hand5Rank r) {
+    if (r.category == Hand5Category.straightFlush) {
+      // Royal Flush (Ace-high straight flush) = 25, otherwise 15
+      return (r.tiebreakers.isNotEmpty && r.tiebreakers[0] == 14) ? 25 : 15;
+    }
     return switch (r.category) {
       Hand5Category.straight => 2,
       Hand5Category.flush => 4,
       Hand5Category.fullHouse => 6,
       Hand5Category.fourOfAKind => 10,
-      Hand5Category.straightFlush => 15,
       _ => 0,
     };
-  }
-
-  int royaltyMiddleWild(Hand5Rank r) {
-    return switch (r.category) {
-      Hand5Category.threeOfAKind => r.isWild ? 1 : 2,
-      Hand5Category.straight => r.isWild ? 3 : 4,
-      Hand5Category.flush => r.isWild ? 6 : 8,
-      Hand5Category.fullHouse => r.isWild ? 10 : 12,
-      Hand5Category.fourOfAKind => r.isWild ? 16 : 20,
-      Hand5Category.straightFlush => r.isWild ? 25 : 30,
-      _ => 0,
-    };
-  }
-
-  int royaltyBottomWild(Hand5Rank r) {
-    return switch (r.category) {
-      Hand5Category.straight => r.isWild ? 1 : 2,
-      Hand5Category.flush => r.isWild ? 3 : 4,
-      Hand5Category.fullHouse => r.isWild ? 5 : 6,
-      Hand5Category.fourOfAKind => r.isWild ? 8 : 10,
-      Hand5Category.straightFlush => r.isWild ? 12 : 15,
-      _ => 0,
-    };
-  }
-
-  int royaltyTopWild(Hand3Rank r) {
-    if (r.category == Hand3Category.threeOfAKind) {
-      final rank = r.tiebreakers.first;
-      if (rank == 14) return r.isWild ? 18 : 22; // AAA
-      return switch (rank) {
-            2 => r.isWild ? 5 : 7,
-            3 => r.isWild ? 6 : 8,
-            4 => r.isWild ? 7 : 9,
-            5 => r.isWild ? 8 : 10,
-            6 => r.isWild ? 9 : 11,
-            7 => r.isWild ? 10 : 12,
-            8 => r.isWild ? 11 : 13,
-            9 => r.isWild ? 12 : 14,
-            10 => r.isWild ? 13 : 15,
-            11 => r.isWild ? 14 : 16,
-            12 => r.isWild ? 15 : 17,
-            13 => r.isWild ? 16 : 18,
-            _ => 0,
-          } +
-          (r.isWild ? -2 : 0);
-    }
-    if (r.category == Hand3Category.pair) {
-      final pair = r.tiebreakers.first;
-      if (r.isWild) {
-        // Wild pairs: slightly reduced
-        if (pair >= 6 && pair <= 10) return 0;
-        return switch (pair) {
-          11 => 1,
-          12 => 2,
-          13 => 3,
-          14 => 4,
-          _ => 0,
-        };
-      }
-      // Natural pairs: standard
-      if (pair >= 6 && pair <= 10) return 1;
-      return switch (pair) {
-        11 => 2,
-        12 => 3,
-        13 => 4,
-        14 => 5,
-        _ => 0,
-      };
-    }
-    return 0;
   }
 }

--- a/lib/features/game/domain/score_engine.dart
+++ b/lib/features/game/domain/score_engine.dart
@@ -79,23 +79,12 @@ class ScoreEngine {
     final aSweep = (rows.sum == 3) ? ruleset.sweepBonus : 0;
     final bSweep = (rows.sum == -3) ? ruleset.sweepBonus : 0;
 
-    final int aRoyal;
-    final int bRoyal;
-    if (wildMode != WildMode.none) {
-      aRoyal = ruleset.royaltyTopWild(ea.top) +
-          ruleset.royaltyMiddleWild(ea.middle) +
-          ruleset.royaltyBottomWild(ea.bottom);
-      bRoyal = ruleset.royaltyTopWild(eb.top) +
-          ruleset.royaltyMiddleWild(eb.middle) +
-          ruleset.royaltyBottomWild(eb.bottom);
-    } else {
-      aRoyal = ruleset.royaltyTop(ea.top) +
-          ruleset.royaltyMiddle(ea.middle) +
-          ruleset.royaltyBottom(ea.bottom);
-      bRoyal = ruleset.royaltyTop(eb.top) +
-          ruleset.royaltyMiddle(eb.middle) +
-          ruleset.royaltyBottom(eb.bottom);
-    }
+    final aRoyal = ruleset.royaltyTop(ea.top) +
+        ruleset.royaltyMiddle(ea.middle) +
+        ruleset.royaltyBottom(ea.bottom);
+    final bRoyal = ruleset.royaltyTop(eb.top) +
+        ruleset.royaltyMiddle(eb.middle) +
+        ruleset.royaltyBottom(eb.bottom);
 
     return VersusScore(
       ScoreBreakdown(rows: rows, sweep: aSweep, royalties: aRoyal, foul: 0),

--- a/test/hand_evaluator_joker_wild_test.dart
+++ b/test/hand_evaluator_joker_wild_test.dart
@@ -166,7 +166,8 @@ void main() {
     });
 
     // OFC foul prevention: Joker should be used as high card when needed
-    test('One joker + K + 6 should be high card (not pair) for OFC top row', () {
+    test('One joker + K + 6 should be high card (not pair) for OFC top row',
+        () {
       // In OFC, we may need to NOT make a pair to avoid foul
       // Joker, K, 6 should be evaluated as K-high (K, Joker as A, 6)
       // NOT as pair of Kings which would cause foul if middle is weaker

--- a/test/royalty_scorer_test.dart
+++ b/test/royalty_scorer_test.dart
@@ -6,12 +6,14 @@ import 'helpers.dart';
 void main() {
   final rules = Ruleset.defaultRules;
   test('top pair/trips royalties (baseline from docs)', () {
+    // Pairs: 66:1, 77:2, 88:3, 99:4, TT:5, JJ:6, QQ:7, KK:8, AA:9
     final topJJ = HandEvaluator.evaluate3([c('Jc'), c('Jd'), c('2h')]);
-    expect(rules.royaltyTop(topJJ), 2);
+    expect(rules.royaltyTop(topJJ), 6);
     final topAA = HandEvaluator.evaluate3([c('As'), c('Ad'), c('7c')]);
-    expect(rules.royaltyTop(topAA), 5);
+    expect(rules.royaltyTop(topAA), 9);
+    // Trips: 222:10, 333:11, ..., KKK:21, AAA:22
     final t222 = HandEvaluator.evaluate3([c('2s'), c('2d'), c('2c')]);
-    expect(rules.royaltyTop(t222), 7);
+    expect(rules.royaltyTop(t222), 10);
     final tAAA = HandEvaluator.evaluate3([c('As'), c('Ah'), c('Ad')]);
     expect(rules.royaltyTop(tAAA), 22);
   });

--- a/test/score_engine_test.dart
+++ b/test/score_engine_test.dart
@@ -19,8 +19,11 @@ void main() {
     final res = ScoreEngine.compare(a, b, ruleset: Ruleset.defaultRules);
     final aTotal = res.a.total;
     final bTotal = res.b.total;
-    // A wins all 3 rows (+3), sweep (+3), top royalty +1。B top royalty +1。
-    expect(aTotal, 7);
-    expect(bTotal, -2);
+    // A wins all 3 rows (+3), sweep (+3), top royalty +4 (99 pair)
+    // B top royalty +3 (88 pair)
+    // A total: 3 + 3 + 4 = 10
+    // B total: -3 + 0 + 3 = 0
+    expect(aTotal, 10);
+    expect(bTotal, 0);
   });
 }


### PR DESCRIPTION
- Update Top pair royalties: 66:1, 77:2, 88:3, 99:4, TT:5, JJ:6, QQ:7, KK:8, AA:9
- Update Top trips royalties: 222:10, 333:11, ..., KKK:21, AAA:22
- Add Royal Flush royalties: Middle:50, Bottom:25 (vs Straight Flush 30/15)
- Remove Wild/Natural royalty difference (same points for both)
- Delete unused royaltyTopWild, royaltyMiddleWild, royaltyBottomWild functions

```
prompt: 得点計算のロジックってどうなってましたっけ？
----
得点計算ロジックの説明をした
----
prompt: WildとNatureで点数差は付けないでください。
トップのペアの点数がおかしいです。
https://pbs.twimg.com/media/CZ0olChUYAAULDp?format=png&name=4096x4096　この図の通りにしてください。
----
ペアの点数を66:1～AA:9に修正、Wild/Natural差を削除
----
prompt: それで正しいのでそれを反映してください
また、middle bottom でロイヤルがないので計算に入れてください
----
Royal Flush点数（Middle:50, Bottom:25）を追加
```