### PR TITLE
fix: optimize Deuces Wild top hand to prevent foul

### DIFF
--- a/lib/features/game/domain/board.dart
+++ b/lib/features/game/domain/board.dart
@@ -1,4 +1,5 @@
 import '../../../core/models/playing_card.dart';
+import '../../../core/models/rank.dart';
 import 'game_options.dart';
 import 'hand_category3.dart';
 import 'hand_category5.dart';
@@ -20,11 +21,11 @@ class BoardEval {
 
   factory BoardEval.from(Board b, {WildMode wildMode = WildMode.none}) {
     if (wildMode == WildMode.deuces) {
-      return BoardEval(
-        top: HandEvaluator.evaluate3DeucesWild(b.top),
-        middle: HandEvaluator.evaluate5DeucesWild(b.middle),
-        bottom: HandEvaluator.evaluate5DeucesWild(b.bottom),
-      );
+      final middle = HandEvaluator.evaluate5DeucesWild(b.middle);
+      final bottom = HandEvaluator.evaluate5DeucesWild(b.bottom);
+      // Optimize top with context-awareness to avoid foul
+      final top = _optimizeTopDeucesWild(b.top, middle);
+      return BoardEval(top: top, middle: middle, bottom: bottom);
     }
     if (wildMode == WildMode.joker) {
       final middle = HandEvaluator.evaluate5JokerWild(b.middle);
@@ -136,6 +137,150 @@ class BoardEval {
         allRanks.add(jokerVal);
       }
       allRanks.sort((a, b) => b - a);
+
+      final evalTry = Hand3Rank(
+          Hand3Category.highCard, allRanks.take(3).toList(),
+          isWild: true);
+      if (!_wouldCauseFoul(evalTry, middle)) {
+        return evalTry;
+      }
+    }
+
+    return null; // No alternative found
+  }
+
+  /// Optimize top hand with deuces to avoid foul when possible.
+  /// Tries the best evaluation first, then finds alternatives if it would cause foul.
+  static Hand3Rank _optimizeTopDeucesWild(
+      List<PlayingCard> topCards, Hand5Rank middle) {
+    final deuceCount =
+        topCards.where((c) => c.rank == Rank.two).length;
+    if (deuceCount == 0) {
+      // No deuces, just evaluate normally
+      return HandEvaluator.evaluate3DeucesWild(topCards);
+    }
+
+    final nonDeuces =
+        topCards.where((c) => c.rank != Rank.two).toList();
+    final nonDeuceRanks = nonDeuces.map((c) => c.rank!.value).toList()..sort();
+
+    // Try best evaluation first
+    final bestEval = HandEvaluator.evaluate3DeucesWild(topCards);
+    if (!_wouldCauseFoul(bestEval, middle)) {
+      return bestEval;
+    }
+
+    // Best eval would cause foul; try to find alternative
+    final alternativeEval =
+        _findNonFoulingEvalDeuces(nonDeuceRanks, deuceCount, middle);
+    return alternativeEval ?? bestEval;
+  }
+
+  /// Find a non-fouling evaluation for top with deuces
+  static Hand3Rank? _findNonFoulingEvalDeuces(
+      List<int> nonDeuceRanks, int deuceCount, Hand5Rank middle) {
+    // Count non-deuce ranks
+    final counts = <int, int>{};
+    for (final r in nonDeuceRanks) {
+      counts[r] = (counts[r] ?? 0) + 1;
+    }
+    final maxCount =
+        counts.isEmpty ? 0 : counts.values.reduce((a, b) => a > b ? a : b);
+
+    // Natural pair exists: deuce can make trips
+    // This might be valid if trips <= middle
+    if (deuceCount == 1 && maxCount >= 2) {
+      final pairRank = counts.entries.firstWhere((e) => e.value >= 2).key;
+      final tripsRank =
+          Hand3Rank(Hand3Category.threeOfAKind, [pairRank], isWild: true);
+      if (!_wouldCauseFoul(tripsRank, middle)) {
+        return tripsRank;
+      }
+      // Trips would foul; try pair instead
+      final otherRanks = nonDeuceRanks.where((r) => r != pairRank).toList();
+      final kicker =
+          otherRanks.isEmpty ? 14 : otherRanks.reduce((a, b) => a > b ? a : b);
+      final pairEval =
+          Hand3Rank(Hand3Category.pair, [pairRank, kicker], isWild: true);
+      if (!_wouldCauseFoul(pairEval, middle)) {
+        return pairEval;
+      }
+    }
+
+    // Try making a pair with deuces
+    // Deuces can become any rank to form a pair
+    // Try highest rank pairs first (Aces down)
+    for (int pairVal = 14; pairVal >= 3; pairVal--) {
+      // Skip ranks that exist in non-deuces (would need 2+ to make trips, not pair)
+      // For pair: deuce becomes pairVal, paired with a non-deuce of pairVal
+      // Or: two deuces become a pair of pairVal
+
+      List<int> allRanks;
+      if (deuceCount >= 2) {
+        // Two+ deuces can become a pair of any rank
+        allRanks = [...nonDeuceRanks, pairVal, pairVal];
+        if (deuceCount > 2) {
+          // Third deuce becomes highest kicker
+          allRanks.add(14);
+        }
+      } else {
+        // One deuce: can pair with a non-deuce rank
+        if (nonDeuceRanks.contains(pairVal)) {
+          // Deuce matches an existing card
+          allRanks = [...nonDeuceRanks, pairVal];
+        } else {
+          continue; // Can't make this pair with one deuce
+        }
+      }
+
+      // Build the hand from allRanks
+      final testCounts = <int, int>{};
+      for (final r in allRanks) {
+        testCounts[r] = (testCounts[r] ?? 0) + 1;
+      }
+
+      // Check if we have a pair (not trips or better)
+      final pairs = testCounts.entries.where((e) => e.value == 2).toList();
+      final trips = testCounts.entries.where((e) => e.value >= 3).toList();
+
+      if (trips.isNotEmpty) continue; // Skip if it makes trips
+
+      if (pairs.isNotEmpty) {
+        final pair = pairs.reduce((a, b) => a.key > b.key ? a : b);
+        final kickers = allRanks.where((r) => r != pair.key).toList()
+          ..sort((a, b) => b - a);
+        final kicker =
+            kickers.isEmpty ? 14 : kickers.first;
+        final pairEval =
+            Hand3Rank(Hand3Category.pair, [pair.key, kicker], isWild: true);
+        if (!_wouldCauseFoul(pairEval, middle)) {
+          return pairEval;
+        }
+      }
+    }
+
+    // Try high card configurations with deuces at various values
+    for (int deuceVal = 14; deuceVal >= 3; deuceVal--) {
+      // Skip if deuce value would match a non-deuce rank (creating a pair)
+      if (nonDeuceRanks.contains(deuceVal)) continue;
+
+      final allRanks = [...nonDeuceRanks];
+      for (int d = 0; d < deuceCount; d++) {
+        // Each additional deuce at a different value
+        var val = deuceVal - d;
+        while (allRanks.contains(val) || val <= 2) {
+          val--;
+        }
+        if (val >= 3) allRanks.add(val);
+      }
+      allRanks.sort((a, b) => b - a);
+
+      // Ensure no pairs
+      final testCounts = <int, int>{};
+      for (final r in allRanks) {
+        testCounts[r] = (testCounts[r] ?? 0) + 1;
+      }
+      if (testCounts.values.any((c) => c >= 2)) continue;
 
       final evalTry = Hand3Rank(
           Hand3Category.highCard, allRanks.take(3).toList(),

--- a/lib/features/game/domain/board.dart
+++ b/lib/features/game/domain/board.dart
@@ -153,15 +153,13 @@ class BoardEval {
   /// Tries the best evaluation first, then finds alternatives if it would cause foul.
   static Hand3Rank _optimizeTopDeucesWild(
       List<PlayingCard> topCards, Hand5Rank middle) {
-    final deuceCount =
-        topCards.where((c) => c.rank == Rank.two).length;
+    final deuceCount = topCards.where((c) => c.rank == Rank.two).length;
     if (deuceCount == 0) {
       // No deuces, just evaluate normally
       return HandEvaluator.evaluate3DeucesWild(topCards);
     }
 
-    final nonDeuces =
-        topCards.where((c) => c.rank != Rank.two).toList();
+    final nonDeuces = topCards.where((c) => c.rank != Rank.two).toList();
     final nonDeuceRanks = nonDeuces.map((c) => c.rank!.value).toList()..sort();
 
     // Try best evaluation first
@@ -249,8 +247,7 @@ class BoardEval {
         final pair = pairs.reduce((a, b) => a.key > b.key ? a : b);
         final kickers = allRanks.where((r) => r != pair.key).toList()
           ..sort((a, b) => b - a);
-        final kicker =
-            kickers.isEmpty ? 14 : kickers.first;
+        final kicker = kickers.isEmpty ? 14 : kickers.first;
         final pairEval =
             Hand3Rank(Hand3Category.pair, [pair.key, kicker], isWild: true);
         if (!_wouldCauseFoul(pairEval, middle)) {

--- a/test/foul_checker_test.dart
+++ b/test/foul_checker_test.dart
@@ -51,19 +51,19 @@ void main() {
     });
 
     test('Deuces in top with one deuce should optimize to pair not trips', () {
-      // Top: 2s Ts Ts (one deuce + pair of Tens)
-      // Without optimization: trips Tens
-      // With optimization: should stay as pair of Tens if middle is also pair
+      // Top: 2s 6s 6d (one deuce + pair of 6s)
+      // Without optimization: trips 6s (deuce becomes a 6)
+      // With optimization: should stay as pair of 6s since trips > pair of 7s
       // Middle: 7h 7d Kc Qs 8h (pair of 7s)
       // Bottom: As Ad Ah 2c 3c (three of a kind Aces)
       final b = Board(
-        top: [c('2s'), c('Ts'), c('Td')],
+        top: [c('2s'), c('6s'), c('6d')],
         middle: [c('7h'), c('7d'), c('Kc'), c('Qs'), c('8h')],
         bottom: [c('As'), c('Ad'), c('Ah'), c('2c'), c('3c')],
       );
       final e = BoardEval.from(b, wildMode: WildMode.deuces);
-      // Top should be pair (TT with kicker) not trips
-      // Because middle is pair of 7s which is less than trips
+      // Top should be pair (66 with kicker) not trips
+      // Because trips 6s > pair of 7s (foul), but pair of 6s < pair of 7s (no foul)
       expect(FoulChecker.isFoul(e), isFalse);
     });
   });

--- a/test/foul_checker_test.dart
+++ b/test/foul_checker_test.dart
@@ -29,6 +29,45 @@ void main() {
     expect(FoulChecker.isFoul(e), isTrue);
   });
 
+  group('Deuces Wild foul prevention', () {
+    test(
+        'Deuces in top should be optimized to not exceed middle (seed 194281128)',
+        () {
+      // Top: 2s 2d Ts (two deuces + Ten)
+      // Without optimization: trips Tens (2s and 2d become Tens)
+      // With optimization: should be AA pair (best pair that doesn't exceed two pair)
+      // Middle: 8c 6s 8d 3c 3d (two pair: 8s and 3s)
+      // Bottom: Qd Ts Kh Kd Qh (two pair: Kings and Queens)
+      final b = Board(
+        top: [c('2s'), c('2d'), c('Ts')],
+        middle: [c('8c'), c('6s'), c('8d'), c('3c'), c('3d')],
+        bottom: [c('Qd'), c('Ts'), c('Kh'), c('Kd'), c('Qh')],
+      );
+      final e = BoardEval.from(b, wildMode: WildMode.deuces);
+      // This should NOT be foul because deuces in top should be optimized
+      // to not exceed middle's strength (two pair)
+      // Top should become pair of Aces (best pair) instead of trips
+      expect(FoulChecker.isFoul(e), isFalse);
+    });
+
+    test('Deuces in top with one deuce should optimize to pair not trips', () {
+      // Top: 2s Ts Ts (one deuce + pair of Tens)
+      // Without optimization: trips Tens
+      // With optimization: should stay as pair of Tens if middle is also pair
+      // Middle: 7h 7d Kc Qs 8h (pair of 7s)
+      // Bottom: As Ad Ah 2c 3c (three of a kind Aces)
+      final b = Board(
+        top: [c('2s'), c('Ts'), c('Td')],
+        middle: [c('7h'), c('7d'), c('Kc'), c('Qs'), c('8h')],
+        bottom: [c('As'), c('Ad'), c('Ah'), c('2c'), c('3c')],
+      );
+      final e = BoardEval.from(b, wildMode: WildMode.deuces);
+      // Top should be pair (TT with kicker) not trips
+      // Because middle is pair of 7s which is less than trips
+      expect(FoulChecker.isFoul(e), isFalse);
+    });
+  });
+
   group('Joker Wild foul prevention', () {
     test(
         'Joker in top should not cause foul when middle is high card - context-aware evaluation',


### PR DESCRIPTION
Add context-aware top hand evaluation for Deuces Wild mode, similar
to the existing Joker Wild optimization. When deuces in the top hand
would create a hand stronger than the middle (causing foul), the
optimizer now finds the strongest alternative that doesn't exceed
the middle hand's rank.

For example, with top [2s 2d Ts] and middle two pair, instead of
evaluating as trips (which fouls), it now evaluates as pair of Aces
(the strongest pair that doesn't exceed two pair).

Fixes seed 194281128 scenario where top was incorrectly evaluated as
trips instead of one pair.