### PR TITLE
feat: add back button confirmation dialog to prevent accidental game exit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,15 @@
 - Conventional Commits（例: `feat(game): unify next3 button`）。小さく分割し CI グリーンで提出。
 - PR には目的/変更点/テスト結果、UI変更はスクショを添付。
 
+## プラットフォーム優先順位
+
+**Web が最優先プラットフォーム**。続いて Android/iOS の順。
+
+機能実装やバグ修正時は:
+1. まず Web で正しく動作することを確認
+2. 次に Android/iOS で確認
+
+※ macos/windows/linux は削除済
+
 ## 署名/セキュリティ
 - 機密情報はコミット禁止。iOS 実機は Xcode で Team を選択し自動署名（`make app-ios-open`）。
-- 対応プラットフォーム: Android/iOS/Web（macos/windows/linux は削除済）。

--- a/app/lib/game_screen.dart
+++ b/app/lib/game_screen.dart
@@ -211,29 +211,27 @@ class _GameScreenState extends State<GameScreen> {
     return 'Practice';
   }
 
-  Future<bool> _onWillPop() async {
-    // If game is in progress, show confirmation dialog
-    if (_eng != null && _eng!.phase == Phase.placing) {
-      final shouldPop = await showDialog<bool>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('Discard game?'),
-          content: const Text('Your current game progress will be lost. Are you sure you want to go back?'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(false),
-              child: const Text('Cancel'),
-            ),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(true),
-              child: const Text('Discard'),
-            ),
-          ],
-        ),
-      );
-      return shouldPop ?? false;
+  Future<void> _showDiscardDialog() async {
+    final shouldPop = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Discard game?'),
+        content: const Text('Your current game progress will be lost. Are you sure you want to go back?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Discard'),
+          ),
+        ],
+      ),
+    );
+    if (shouldPop == true && context.mounted) {
+      Navigator.pop(context);
     }
-    return true;
   }
 
   @override
@@ -252,8 +250,14 @@ class _GameScreenState extends State<GameScreen> {
     final screenSize = MediaQuery.of(context).size;
     final isSmallScreen = screenSize.width < 600;
 
-    return WillPopScope(
-      onWillPop: _onWillPop,
+    return PopScope(
+      canPop: !(_eng != null && _eng!.phase == Phase.placing),
+      onPopInvoked: (bool didPop) async {
+        if (didPop) {
+          return;
+        }
+        _showDiscardDialog();
+      },
       child: Scaffold(
       appBar: AppBar(
         title: Text(_modeTitle()),

--- a/app/lib/game_screen.dart
+++ b/app/lib/game_screen.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:ofc_app_core/core/models/deck.dart';
 import 'package:ofc_app_core/core/models/playing_card.dart';
@@ -375,15 +378,25 @@ class _GameScreenState extends State<GameScreen> {
                                       FantasyEngine.nextState(_fantasy, e);
                                   final nextInit =
                                       await Navigator.of(context).push<int>(
-                                    MaterialPageRoute(
-                                      builder: (_) => ResultScreen(
-                                          board: b,
-                                          nextFantasy: next,
-                                          ruleset: _ruleset,
-                                          seed: widget.seed,
-                                          wildMode: wildMode,
-                                          history: List.of(_eng!.history)),
-                                    ),
+                                    !kIsWeb && Platform.isIOS
+                                        ? CupertinoPageRoute(
+                                            builder: (_) => ResultScreen(
+                                                board: b,
+                                                nextFantasy: next,
+                                                ruleset: _ruleset,
+                                                seed: widget.seed,
+                                                wildMode: wildMode,
+                                                history: List.of(_eng!.history)),
+                                          )
+                                        : MaterialPageRoute(
+                                            builder: (_) => ResultScreen(
+                                                board: b,
+                                                nextFantasy: next,
+                                                ruleset: _ruleset,
+                                                seed: widget.seed,
+                                                wildMode: wildMode,
+                                                history: List.of(_eng!.history)),
+                                          ),
                                   );
                                   setState(() {
                                     _fantasy = next;

--- a/app/lib/game_screen.dart
+++ b/app/lib/game_screen.dart
@@ -1,16 +1,14 @@
-import 'dart:io';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:ofc_app_core/core/models/deck.dart';
 import 'package:ofc_app_core/core/models/playing_card.dart';
 import 'package:ofc_app_core/features/game/domain/board.dart';
+import 'package:ofc_app_core/features/game/domain/cycle_logic.dart';
 import 'package:ofc_app_core/features/game/domain/fantasy_engine.dart';
 import 'package:ofc_app_core/features/game/domain/game_options.dart';
+import 'package:ofc_app_core/features/game/domain/pineapple_engine.dart';
 import 'package:ofc_app_core/features/game/domain/ruleset.dart';
 import 'result_screen.dart';
-import 'package:ofc_app_core/features/game/domain/cycle_logic.dart';
-import 'package:ofc_app_core/features/game/domain/pineapple_engine.dart';
+import 'utils/navigation_utils.dart';
 import 'widgets/card_widget.dart';
 
 class GameScreen extends StatefulWidget {
@@ -214,25 +212,9 @@ class _GameScreenState extends State<GameScreen> {
     return 'Practice';
   }
 
-  Future<void> _showDiscardDialog() async {
-    final shouldPop = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Discard game?'),
-        content: const Text('Your current game progress will be lost. Are you sure you want to go back?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Discard'),
-          ),
-        ],
-      ),
-    );
-    if (shouldPop == true && context.mounted) {
+  Future<void> _handleBackPress() async {
+    final shouldPop = await showDiscardConfirmationDialog(context);
+    if (shouldPop && context.mounted) {
       Navigator.pop(context);
     }
   }
@@ -255,191 +237,188 @@ class _GameScreenState extends State<GameScreen> {
 
     return PopScope(
       canPop: !(_eng != null && _eng!.phase == Phase.placing),
-      onPopInvoked: (bool didPop) async {
-        if (didPop) {
-          return;
-        }
-        _showDiscardDialog();
+      onPopInvokedWithResult: (bool didPop, _) {
+        if (didPop) return;
+        _handleBackPress();
       },
       child: Scaffold(
-      appBar: AppBar(
-        title: Text(_modeTitle()),
-        centerTitle: true,
-      ),
-      body: SingleChildScrollView(
-        child: Padding(
-          padding: EdgeInsets.all(isSmallScreen ? 8 : 16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const SizedBox(height: 12),
-              Text('Status: $_status'),
-              const SizedBox(height: 4),
-              Align(
-                alignment: Alignment.centerLeft,
-                child: SelectableText('Seed: ${widget.seed}',
-                    style: const TextStyle(color: Colors.grey)),
-              ),
-              const SizedBox(height: 8),
-              const Divider(),
-              _dropZone(title: 'Top', current: top, max: 3, slot: Slot.top),
-              SizedBox(height: isSmallScreen ? 4 : 8),
-              _dropZone(
-                  title: 'Middle', current: middle, max: 5, slot: Slot.middle),
-              SizedBox(height: isSmallScreen ? 4 : 8),
-              _dropZone(
-                  title: 'Bottom', current: bottom, max: 5, slot: Slot.bottom),
-              const Divider(),
-              DragTarget<PlayingCard>(
-                onWillAcceptWithDetails: (details) {
-                  final eng2 = _eng;
-                  if (eng2 == null) return false;
-                  // Already in Tray
-                  if (eng2.tray.contains(details.data)) {
-                    return false;
-                  }
-                  if (eng2.phase != Phase.placing) return false;
-                  // Only cards from the current cycle can be returned to the Tray
-                  final ids = _currentCycleIds();
-                  return ids.contains(details.data.toString());
-                },
-                onAcceptWithDetails: (details) => setState(() {
-                  final eng2 = _eng!;
-                  // Return card from board to tray
-                  eng2.returnToTray(details.data);
-                  _status = 'Back to Tray';
-                }),
-                builder: (context, cand, rej) => Container(
-                  padding: const EdgeInsets.all(10),
-                  decoration: BoxDecoration(
-                    border: Border.all(
-                        color:
-                            cand.isNotEmpty ? Colors.blue : Colors.transparent),
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      Text('Tray (${tray.length})',
-                          textAlign: TextAlign.center),
-                      const SizedBox(height: 8),
-                      Wrap(
-                        spacing: 6,
-                        runSpacing: 6,
-                        children: [
-                          for (final c in tray)
-                            Draggable<PlayingCard>(
-                              data: c,
-                              feedback: Material(
-                                  color: Colors.transparent,
-                                  child: _cardWidget(c,
-                                      large: true,
-                                      isSmallScreen: isSmallScreen)),
-                              childWhenDragging: Opacity(
-                                  opacity: 0.3,
-                                  child: _cardWidget(c,
-                                      isSmallScreen: isSmallScreen)),
-                              child:
-                                  _cardWidget(c, isSmallScreen: isSmallScreen),
-                            ),
-                        ],
-                      ),
-                    ],
+        appBar: AppBar(
+          title: Text(_modeTitle()),
+          centerTitle: true,
+        ),
+        body: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.all(isSmallScreen ? 8 : 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: 12),
+                Text('Status: $_status'),
+                const SizedBox(height: 4),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: SelectableText('Seed: ${widget.seed}',
+                      style: const TextStyle(color: Colors.grey)),
+                ),
+                const SizedBox(height: 8),
+                const Divider(),
+                _dropZone(title: 'Top', current: top, max: 3, slot: Slot.top),
+                SizedBox(height: isSmallScreen ? 4 : 8),
+                _dropZone(
+                    title: 'Middle',
+                    current: middle,
+                    max: 5,
+                    slot: Slot.middle),
+                SizedBox(height: isSmallScreen ? 4 : 8),
+                _dropZone(
+                    title: 'Bottom',
+                    current: bottom,
+                    max: 5,
+                    slot: Slot.bottom),
+                const Divider(),
+                DragTarget<PlayingCard>(
+                  onWillAcceptWithDetails: (details) {
+                    final eng2 = _eng;
+                    if (eng2 == null) return false;
+                    // Already in Tray
+                    if (eng2.tray.contains(details.data)) {
+                      return false;
+                    }
+                    if (eng2.phase != Phase.placing) return false;
+                    // Only cards from the current cycle can be returned to the Tray
+                    final ids = _currentCycleIds();
+                    return ids.contains(details.data.toString());
+                  },
+                  onAcceptWithDetails: (details) => setState(() {
+                    final eng2 = _eng!;
+                    // Return card from board to tray
+                    eng2.returnToTray(details.data);
+                    _status = 'Back to Tray';
+                  }),
+                  builder: (context, cand, rej) => Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                          color: cand.isNotEmpty
+                              ? Colors.blue
+                              : Colors.transparent),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text('Tray (${tray.length})',
+                            textAlign: TextAlign.center),
+                        const SizedBox(height: 8),
+                        Wrap(
+                          spacing: 6,
+                          runSpacing: 6,
+                          children: [
+                            for (final c in tray)
+                              Draggable<PlayingCard>(
+                                data: c,
+                                feedback: Material(
+                                    color: Colors.transparent,
+                                    child: _cardWidget(c,
+                                        large: true,
+                                        isSmallScreen: isSmallScreen)),
+                                childWhenDragging: Opacity(
+                                    opacity: 0.3,
+                                    child: _cardWidget(c,
+                                        isSmallScreen: isSmallScreen)),
+                                child: _cardWidget(c,
+                                    isSmallScreen: isSmallScreen),
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: [
-                  if (eng != null && eng.initialDrawCount > 5)
-                    Expanded(
-                      child: ElevatedButton(
-                        onPressed: tray.length >= 2 ? _sortTray : null,
-                        child: const Text('Sort'),
-                      ),
-                    ),
-                  if (eng != null && eng.initialDrawCount > 5)
-                    const SizedBox(width: 0),
-                  Expanded(
-                    child: Builder(builder: (context) {
-                      final isFinal = eng?.builder.isComplete == true;
-                      final label = isFinal ? 'Commit' : 'Next 3';
-                      final enabled = eng != null && (isFinal ? true : canNext);
-                      return ElevatedButton(
-                        onPressed: !enabled
-                            ? null
-                            : () async {
-                                if (isFinal) {
-                                  final b = _eng!.finalize();
-                                  final wildMode = widget.options.wildMode;
-                                  final e =
-                                      BoardEval.from(b, wildMode: wildMode);
-                                  final next =
-                                      FantasyEngine.nextState(_fantasy, e);
-                                  final nextInit =
-                                      await Navigator.of(context).push<int>(
-                                    !kIsWeb && Platform.isIOS
-                                        ? CupertinoPageRoute(
-                                            builder: (_) => ResultScreen(
-                                                board: b,
-                                                nextFantasy: next,
-                                                ruleset: _ruleset,
-                                                seed: widget.seed,
-                                                wildMode: wildMode,
-                                                history: List.of(_eng!.history)),
-                                          )
-                                        : MaterialPageRoute(
-                                            builder: (_) => ResultScreen(
-                                                board: b,
-                                                nextFantasy: next,
-                                                ruleset: _ruleset,
-                                                seed: widget.seed,
-                                                wildMode: wildMode,
-                                                history: List.of(_eng!.history)),
-                                          ),
-                                  );
-                                  setState(() {
-                                    _fantasy = next;
-                                    _eng = null;
-                                    _status = 'Ready';
-                                  });
-                                  if (nextInit != null) {
-                                    _deal();
-                                  }
-                                } else {
-                                  setState(() {
-                                    final eng2 = _eng!;
-                                    CycleLogic.autoDiscardForNext(eng2);
-                                    eng2.nextCycle();
-                                    _status = 'Drew 3';
-                                  });
-                                }
-                              },
-                        child: Text(label),
-                      );
-                    }),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 8),
-              if (eng != null && eng.discards.isNotEmpty) ...[
-                Text('Discarded (${eng.discards.length})',
-                    textAlign: TextAlign.center),
-                const SizedBox(height: 6),
-                Wrap(
-                  alignment: WrapAlignment.center,
-                  spacing: 6,
-                  runSpacing: 6,
+                const SizedBox(height: 12),
+                Row(
                   children: [
-                    for (final c in eng.discards)
-                      _cardWidget(c, isSmallScreen: isSmallScreen)
+                    if (eng != null && eng.initialDrawCount > 5)
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: tray.length >= 2 ? _sortTray : null,
+                          child: const Text('Sort'),
+                        ),
+                      ),
+                    if (eng != null && eng.initialDrawCount > 5)
+                      const SizedBox(width: 0),
+                    Expanded(
+                      child: Builder(builder: (context) {
+                        final isFinal = eng?.builder.isComplete == true;
+                        final label = isFinal ? 'Commit' : 'Next 3';
+                        final enabled =
+                            eng != null && (isFinal ? true : canNext);
+                        return ElevatedButton(
+                          onPressed: !enabled
+                              ? null
+                              : () async {
+                                  if (isFinal) {
+                                    final b = _eng!.finalize();
+                                    final wildMode = widget.options.wildMode;
+                                    final e =
+                                        BoardEval.from(b, wildMode: wildMode);
+                                    final next =
+                                        FantasyEngine.nextState(_fantasy, e);
+                                    final nextInit =
+                                        await Navigator.of(context).push<int>(
+                                      adaptiveRoute(
+                                        (_) => ResultScreen(
+                                          board: b,
+                                          nextFantasy: next,
+                                          ruleset: _ruleset,
+                                          seed: widget.seed,
+                                          wildMode: wildMode,
+                                          history: List.of(_eng!.history),
+                                        ),
+                                      ),
+                                    );
+                                    setState(() {
+                                      _fantasy = next;
+                                      _eng = null;
+                                      _status = 'Ready';
+                                    });
+                                    if (nextInit != null) {
+                                      _deal();
+                                    }
+                                  } else {
+                                    setState(() {
+                                      final eng2 = _eng!;
+                                      CycleLogic.autoDiscardForNext(eng2);
+                                      eng2.nextCycle();
+                                      _status = 'Drew 3';
+                                    });
+                                  }
+                                },
+                          child: Text(label),
+                        );
+                      }),
+                    ),
                   ],
                 ),
+                const SizedBox(height: 8),
+                if (eng != null && eng.discards.isNotEmpty) ...[
+                  Text('Discarded (${eng.discards.length})',
+                      textAlign: TextAlign.center),
+                  const SizedBox(height: 6),
+                  Wrap(
+                    alignment: WrapAlignment.center,
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: [
+                      for (final c in eng.discards)
+                        _cardWidget(c, isSmallScreen: isSmallScreen)
+                    ],
+                  ),
+                ],
               ],
-            ],
+            ),
           ),
         ),
-      ),
       ),
     );
   }

--- a/app/lib/game_screen.dart
+++ b/app/lib/game_screen.dart
@@ -213,9 +213,10 @@ class _GameScreenState extends State<GameScreen> {
   }
 
   Future<void> _handleBackPress() async {
+    final navigator = Navigator.of(context);
     final shouldPop = await showDiscardConfirmationDialog(context);
     if (shouldPop && context.mounted) {
-      Navigator.pop(context);
+      navigator.pop();
     }
   }
 

--- a/app/lib/game_screen.dart
+++ b/app/lib/game_screen.dart
@@ -211,6 +211,31 @@ class _GameScreenState extends State<GameScreen> {
     return 'Practice';
   }
 
+  Future<bool> _onWillPop() async {
+    // If game is in progress, show confirmation dialog
+    if (_eng != null && _eng!.phase == Phase.placing) {
+      final shouldPop = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Discard game?'),
+          content: const Text('Your current game progress will be lost. Are you sure you want to go back?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Discard'),
+            ),
+          ],
+        ),
+      );
+      return shouldPop ?? false;
+    }
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
     final eng = _eng;
@@ -227,7 +252,9 @@ class _GameScreenState extends State<GameScreen> {
     final screenSize = MediaQuery.of(context).size;
     final isSmallScreen = screenSize.width < 600;
 
-    return Scaffold(
+    return WillPopScope(
+      onWillPop: _onWillPop,
+      child: Scaffold(
       appBar: AppBar(
         title: Text(_modeTitle()),
         centerTitle: true,
@@ -395,6 +422,7 @@ class _GameScreenState extends State<GameScreen> {
             ],
           ),
         ),
+      ),
       ),
     );
   }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:ofc_app_core/features/game/domain/game_options.dart';
 import 'game_screen.dart';
@@ -20,6 +23,15 @@ class OfcApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
     );
   }
+}
+
+/// Creates a platform-adaptive route for better PopScope support
+/// iOS uses CupertinoPageRoute for proper swipe-back gesture handling
+Route<T> _adaptiveRoute<T>(WidgetBuilder builder) {
+  if (!kIsWeb && Platform.isIOS) {
+    return CupertinoPageRoute<T>(builder: builder);
+  }
+  return MaterialPageRoute<T>(builder: builder);
 }
 
 class HomePage extends StatefulWidget {
@@ -124,9 +136,8 @@ class _HomePageState extends State<HomePage> {
                     // The seed is passed to GameScreen and displayed on the screen/result screen
                     // ignore: use_build_context_synchronously
                     Navigator.of(context).push(
-                      MaterialPageRoute(
-                          builder: (_) =>
-                              GameScreen(seed: seed, options: _options)),
+                      _adaptiveRoute(
+                          (_) => GameScreen(seed: seed, options: _options)),
                     );
                   },
                   style: ElevatedButton.styleFrom(
@@ -146,8 +157,8 @@ class _HomePageState extends State<HomePage> {
                 child: ElevatedButton(
                   onPressed: () {
                     Navigator.of(context).push(
-                      MaterialPageRoute(
-                          builder: (_) => PassPlayScreen(options: _options)),
+                      _adaptiveRoute(
+                          (_) => PassPlayScreen(options: _options)),
                     );
                   },
                   style: ElevatedButton.styleFrom(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,10 +1,8 @@
-import 'dart:io';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:ofc_app_core/features/game/domain/game_options.dart';
 import 'game_screen.dart';
 import 'pass_play_screen.dart';
+import 'utils/navigation_utils.dart';
 
 void main() {
   runApp(const OfcApp());
@@ -23,15 +21,6 @@ class OfcApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
     );
   }
-}
-
-/// Creates a platform-adaptive route for better PopScope support
-/// iOS uses CupertinoPageRoute for proper swipe-back gesture handling
-Route<T> _adaptiveRoute<T>(WidgetBuilder builder) {
-  if (!kIsWeb && Platform.isIOS) {
-    return CupertinoPageRoute<T>(builder: builder);
-  }
-  return MaterialPageRoute<T>(builder: builder);
 }
 
 class HomePage extends StatefulWidget {
@@ -136,7 +125,7 @@ class _HomePageState extends State<HomePage> {
                     // The seed is passed to GameScreen and displayed on the screen/result screen
                     // ignore: use_build_context_synchronously
                     Navigator.of(context).push(
-                      _adaptiveRoute(
+                      adaptiveRoute(
                           (_) => GameScreen(seed: seed, options: _options)),
                     );
                   },
@@ -157,8 +146,7 @@ class _HomePageState extends State<HomePage> {
                 child: ElevatedButton(
                   onPressed: () {
                     Navigator.of(context).push(
-                      _adaptiveRoute(
-                          (_) => PassPlayScreen(options: _options)),
+                      adaptiveRoute((_) => PassPlayScreen(options: _options)),
                     );
                   },
                   style: ElevatedButton.styleFrom(

--- a/app/lib/pass_play_screen.dart
+++ b/app/lib/pass_play_screen.dart
@@ -1,14 +1,12 @@
-import 'dart:io';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:ofc_app_core/core/models/playing_card.dart';
 import 'package:ofc_app_core/features/game/domain/cycle_logic.dart';
 import 'package:ofc_app_core/features/game/domain/game_options.dart';
 import 'package:ofc_app_core/features/game/domain/game_state.dart';
 import 'package:ofc_app_core/features/game/domain/pineapple_engine.dart';
-import 'pass_play_result.dart';
 import 'package:ofc_app_core/features/game/domain/score_engine.dart';
+import 'pass_play_result.dart';
+import 'utils/navigation_utils.dart';
 import 'widgets/card_widget.dart';
 
 class PassPlayScreen extends StatefulWidget {
@@ -146,25 +144,16 @@ class _PassPlayScreenState extends State<PassPlayScreen> {
       final vs = gs.lastScore ??
           ScoreEngine.compare(gs.boardA!, gs.boardB!, wildMode: wildMode);
       final _ = await Navigator.of(context).push<bool>(
-        !kIsWeb && Platform.isIOS
-            ? CupertinoPageRoute(
-                builder: (_) => PassPlayResult(
-                    score: vs,
-                    boardA: gs.boardA!,
-                    boardB: gs.boardB!,
-                    nextFantasyA: nextFantasyA,
-                    nextFantasyB: nextFantasyB,
-                    wildMode: wildMode),
-              )
-            : MaterialPageRoute(
-                builder: (_) => PassPlayResult(
-                    score: vs,
-                    boardA: gs.boardA!,
-                    boardB: gs.boardB!,
-                    nextFantasyA: nextFantasyA,
-                    nextFantasyB: nextFantasyB,
-                    wildMode: wildMode),
-              ),
+        adaptiveRoute(
+          (_) => PassPlayResult(
+            score: vs,
+            boardA: gs.boardA!,
+            boardB: gs.boardB!,
+            nextFantasyA: nextFantasyA,
+            nextFantasyB: nextFantasyB,
+            wildMode: wildMode,
+          ),
+        ),
       );
       // Next hand: 個別Dealし、Fantasyのない側から開始
       setState(() {
@@ -208,25 +197,13 @@ class _PassPlayScreenState extends State<PassPlayScreen> {
     return 'Pass & Play';
   }
 
-  Future<void> _showDiscardDialog() async {
-    final shouldPop = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Discard game?'),
-        content: const Text('Both players\' game progress will be lost. Are you sure you want to go back?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Discard'),
-          ),
-        ],
-      ),
+  Future<void> _handleBackPress() async {
+    final shouldPop = await showDiscardConfirmationDialog(
+      context,
+      content:
+          "Both players' game progress will be lost. Are you sure you want to go back?",
     );
-    if (shouldPop == true && context.mounted) {
+    if (shouldPop && context.mounted) {
       Navigator.pop(context);
     }
   }
@@ -245,125 +222,123 @@ class _PassPlayScreenState extends State<PassPlayScreen> {
         isFinal ? 'Commit ${current == Player.a ? '(A)' : '(B)'}' : 'Next 3';
 
     return PopScope(
-      canPop: !(eng.phase == Phase.placing),
-      onPopInvoked: (bool didPop) async {
-        if (didPop) {
-          return;
-        }
-        _showDiscardDialog();
+      canPop: eng.phase != Phase.placing,
+      onPopInvokedWithResult: (bool didPop, _) {
+        if (didPop) return;
+        _handleBackPress();
       },
       child: Scaffold(
-      appBar: AppBar(title: Text(_modeTitle())),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text('Turn: ${current == Player.a ? 'Player A' : 'Player B'}',
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            Text('Status: $status', textAlign: TextAlign.center),
-            const Divider(),
-            _drop('Top', top, 3, Slot.top),
-            const SizedBox(height: 8),
-            _drop('Middle', middle, 5, Slot.middle),
-            const SizedBox(height: 8),
-            _drop('Bottom', bottom, 5, Slot.bottom),
-            const Divider(),
-            // Tray (DragTarget to allow back)
-            DragTarget<PlayingCard>(
-              onWillAcceptWithDetails: (d) {
-                if (eng.phase != Phase.placing) return false;
-                if (eng.tray.contains(d.data)) return false;
-                return ids.contains(d.data.toString());
-              },
-              onAcceptWithDetails: (d) => setState(() {
-                eng.returnToTray(d.data);
-                status = 'Back to Tray';
-              }),
-              builder: (context, cand, _) => Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
+        appBar: AppBar(title: Text(_modeTitle())),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text('Turn: ${current == Player.a ? 'Player A' : 'Player B'}',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
+              Text('Status: $status', textAlign: TextAlign.center),
+              const Divider(),
+              _drop('Top', top, 3, Slot.top),
+              const SizedBox(height: 8),
+              _drop('Middle', middle, 5, Slot.middle),
+              const SizedBox(height: 8),
+              _drop('Bottom', bottom, 5, Slot.bottom),
+              const Divider(),
+              // Tray (DragTarget to allow back)
+              DragTarget<PlayingCard>(
+                onWillAcceptWithDetails: (d) {
+                  if (eng.phase != Phase.placing) return false;
+                  if (eng.tray.contains(d.data)) return false;
+                  return ids.contains(d.data.toString());
+                },
+                onAcceptWithDetails: (d) => setState(() {
+                  eng.returnToTray(d.data);
+                  status = 'Back to Tray';
+                }),
+                builder: (context, cand, _) => Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text('Tray (${tray.length})', textAlign: TextAlign.center),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 6,
+                      runSpacing: 6,
+                      children: [
+                        for (final c in tray)
+                          Draggable<PlayingCard>(
+                            data: c,
+                            feedback: Material(
+                                color: Colors.transparent,
+                                child: _card(c, large: true)),
+                            childWhenDragging:
+                                Opacity(opacity: 0.3, child: _card(c)),
+                            child: _card(c),
+                          ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
                 children: [
-                  Text('Tray (${tray.length})', textAlign: TextAlign.center),
-                  const SizedBox(height: 8),
-                  Wrap(
-                    spacing: 6,
-                    runSpacing: 6,
-                    children: [
-                      for (final c in tray)
-                        Draggable<PlayingCard>(
-                          data: c,
-                          feedback: Material(
-                              color: Colors.transparent,
-                              child: _card(c, large: true)),
-                          childWhenDragging:
-                              Opacity(opacity: 0.3, child: _card(c)),
-                          child: _card(c),
-                        ),
-                    ],
+                  if (eng.initialDrawCount > 5)
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: tray.length >= 2
+                            ? () => setState(() {
+                                  eng.sortTray((a, b) {
+                                    // Handle jokers: put them at the end
+                                    if (a.isJoker && b.isJoker) return 0;
+                                    if (a.isJoker) return 1;
+                                    if (b.isJoker) return -1;
+
+                                    final rv =
+                                        b.rank!.value.compareTo(a.rank!.value);
+                                    if (rv != 0) return rv;
+                                    int suitOrder(String s) => switch (s) {
+                                          'spades' => 3,
+                                          'hearts' => 2,
+                                          'diamonds' => 1,
+                                          _ => 0,
+                                        };
+                                    return suitOrder(b.suit!.name) -
+                                        suitOrder(a.suit!.name);
+                                  });
+                                  status = 'Sorted';
+                                })
+                            : null,
+                        child: const Text('Sort'),
+                      ),
+                    ),
+                  if (eng.initialDrawCount > 5) const SizedBox(width: 0),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: isFinal
+                          ? _onPrimaryButton
+                          : (canNext ? _onPrimaryButton : null),
+                      child: Text(label),
+                    ),
                   ),
                 ],
               ),
-            ),
-            const SizedBox(height: 12),
-            Row(
-              children: [
-                if (eng.initialDrawCount > 5)
-                  Expanded(
-                    child: ElevatedButton(
-                      onPressed: tray.length >= 2
-                          ? () => setState(() {
-                                eng.sortTray((a, b) {
-                                  // Handle jokers: put them at the end
-                                  if (a.isJoker && b.isJoker) return 0;
-                                  if (a.isJoker) return 1;
-                                  if (b.isJoker) return -1;
-
-                                  final rv =
-                                      b.rank!.value.compareTo(a.rank!.value);
-                                  if (rv != 0) return rv;
-                                  int suitOrder(String s) => switch (s) {
-                                        'spades' => 3,
-                                        'hearts' => 2,
-                                        'diamonds' => 1,
-                                        _ => 0,
-                                      };
-                                  return suitOrder(b.suit!.name) -
-                                      suitOrder(a.suit!.name);
-                                });
-                                status = 'Sorted';
-                              })
-                          : null,
-                      child: const Text('Sort'),
-                    ),
-                  ),
-                if (eng.initialDrawCount > 5) const SizedBox(width: 0),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: isFinal
-                        ? _onPrimaryButton
-                        : (canNext ? _onPrimaryButton : null),
-                    child: Text(label),
-                  ),
+              const SizedBox(height: 8),
+              if (eng.discards.isNotEmpty) ...[
+                Text('Your Discards (${eng.discards.length})',
+                    textAlign: TextAlign.center),
+                const SizedBox(height: 6),
+                Wrap(
+                  alignment: WrapAlignment.center,
+                  spacing: 6,
+                  runSpacing: 6,
+                  children: [for (final c in eng.discards) _card(c)],
                 ),
               ],
-            ),
-            const SizedBox(height: 8),
-            if (eng.discards.isNotEmpty) ...[
-              Text('Your Discards (${eng.discards.length})',
-                  textAlign: TextAlign.center),
-              const SizedBox(height: 6),
-              Wrap(
-                alignment: WrapAlignment.center,
-                spacing: 6,
-                runSpacing: 6,
-                children: [for (final c in eng.discards) _card(c)],
-              ),
             ],
-          ],
+          ),
         ),
-      ),
       ),
     );
   }

--- a/app/lib/pass_play_screen.dart
+++ b/app/lib/pass_play_screen.dart
@@ -195,29 +195,27 @@ class _PassPlayScreenState extends State<PassPlayScreen> {
     return 'Pass & Play';
   }
 
-  Future<bool> _onWillPop() async {
-    // If game is in progress, show confirmation dialog
-    if (eng.phase == Phase.placing) {
-      final shouldPop = await showDialog<bool>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('Discard game?'),
-          content: const Text('Both players\' game progress will be lost. Are you sure you want to go back?'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(false),
-              child: const Text('Cancel'),
-            ),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(true),
-              child: const Text('Discard'),
-            ),
-          ],
-        ),
-      );
-      return shouldPop ?? false;
+  Future<void> _showDiscardDialog() async {
+    final shouldPop = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Discard game?'),
+        content: const Text('Both players\' game progress will be lost. Are you sure you want to go back?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Discard'),
+          ),
+        ],
+      ),
+    );
+    if (shouldPop == true && context.mounted) {
+      Navigator.pop(context);
     }
-    return true;
   }
 
   @override
@@ -233,8 +231,14 @@ class _PassPlayScreenState extends State<PassPlayScreen> {
     final label =
         isFinal ? 'Commit ${current == Player.a ? '(A)' : '(B)'}' : 'Next 3';
 
-    return WillPopScope(
-      onWillPop: _onWillPop,
+    return PopScope(
+      canPop: !(eng.phase == Phase.placing),
+      onPopInvoked: (bool didPop) async {
+        if (didPop) {
+          return;
+        }
+        _showDiscardDialog();
+      },
       child: Scaffold(
       appBar: AppBar(title: Text(_modeTitle())),
       body: Padding(

--- a/app/lib/pass_play_screen.dart
+++ b/app/lib/pass_play_screen.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:ofc_app_core/core/models/playing_card.dart';
 import 'package:ofc_app_core/features/game/domain/cycle_logic.dart';
@@ -143,15 +146,25 @@ class _PassPlayScreenState extends State<PassPlayScreen> {
       final vs = gs.lastScore ??
           ScoreEngine.compare(gs.boardA!, gs.boardB!, wildMode: wildMode);
       final _ = await Navigator.of(context).push<bool>(
-        MaterialPageRoute(
-          builder: (_) => PassPlayResult(
-              score: vs,
-              boardA: gs.boardA!,
-              boardB: gs.boardB!,
-              nextFantasyA: nextFantasyA,
-              nextFantasyB: nextFantasyB,
-              wildMode: wildMode),
-        ),
+        !kIsWeb && Platform.isIOS
+            ? CupertinoPageRoute(
+                builder: (_) => PassPlayResult(
+                    score: vs,
+                    boardA: gs.boardA!,
+                    boardB: gs.boardB!,
+                    nextFantasyA: nextFantasyA,
+                    nextFantasyB: nextFantasyB,
+                    wildMode: wildMode),
+              )
+            : MaterialPageRoute(
+                builder: (_) => PassPlayResult(
+                    score: vs,
+                    boardA: gs.boardA!,
+                    boardB: gs.boardB!,
+                    nextFantasyA: nextFantasyA,
+                    nextFantasyB: nextFantasyB,
+                    wildMode: wildMode),
+              ),
       );
       // Next hand: 個別Dealし、Fantasyのない側から開始
       setState(() {

--- a/app/lib/pass_play_screen.dart
+++ b/app/lib/pass_play_screen.dart
@@ -195,6 +195,31 @@ class _PassPlayScreenState extends State<PassPlayScreen> {
     return 'Pass & Play';
   }
 
+  Future<bool> _onWillPop() async {
+    // If game is in progress, show confirmation dialog
+    if (eng.phase == Phase.placing) {
+      final shouldPop = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Discard game?'),
+          content: const Text('Both players\' game progress will be lost. Are you sure you want to go back?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Discard'),
+            ),
+          ],
+        ),
+      );
+      return shouldPop ?? false;
+    }
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
     final tray = eng.tray;
@@ -208,7 +233,9 @@ class _PassPlayScreenState extends State<PassPlayScreen> {
     final label =
         isFinal ? 'Commit ${current == Player.a ? '(A)' : '(B)'}' : 'Next 3';
 
-    return Scaffold(
+    return WillPopScope(
+      onWillPop: _onWillPop,
+      child: Scaffold(
       appBar: AppBar(title: Text(_modeTitle())),
       body: Padding(
         padding: const EdgeInsets.all(16),
@@ -319,6 +346,7 @@ class _PassPlayScreenState extends State<PassPlayScreen> {
             ],
           ],
         ),
+      ),
       ),
     );
   }

--- a/app/lib/pass_play_screen.dart
+++ b/app/lib/pass_play_screen.dart
@@ -198,13 +198,14 @@ class _PassPlayScreenState extends State<PassPlayScreen> {
   }
 
   Future<void> _handleBackPress() async {
+    final navigator = Navigator.of(context);
     final shouldPop = await showDiscardConfirmationDialog(
       context,
       content:
           "Both players' game progress will be lost. Are you sure you want to go back?",
     );
     if (shouldPop && context.mounted) {
-      Navigator.pop(context);
+      navigator.pop();
     }
   }
 

--- a/app/lib/utils/navigation_utils.dart
+++ b/app/lib/utils/navigation_utils.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Creates a platform-adaptive route for better PopScope support.
+/// iOS uses CupertinoPageRoute for proper swipe-back gesture handling.
+Route<T> adaptiveRoute<T>(WidgetBuilder builder) {
+  if (!kIsWeb && Platform.isIOS) {
+    return CupertinoPageRoute<T>(builder: builder);
+  }
+  return MaterialPageRoute<T>(builder: builder);
+}
+
+/// Shows a confirmation dialog when user tries to discard game progress.
+/// Returns true if user confirmed, false otherwise.
+Future<bool> showDiscardConfirmationDialog(
+  BuildContext context, {
+  String title = 'Discard game?',
+  String content =
+      'Your current game progress will be lost. Are you sure you want to go back?',
+}) async {
+  final shouldPop = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(title),
+      content: Text(content),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Discard'),
+        ),
+      ],
+    ),
+  );
+  return shouldPop == true;
+}


### PR DESCRIPTION
- Add WillPopScope to GameScreen to show confirmation dialog when user presses back during active game
- Add WillPopScope to PassPlayScreen to show confirmation dialog for both players
- Prevent accidental loss of game progress when navigating away
- Only show confirmation when game is in placing phase

Resolves #22