### PR TITLE
fix(game): show best wild hands on foul

### DIFF
--- a/lib/features/game/domain/board.dart
+++ b/lib/features/game/domain/board.dart
@@ -22,19 +22,31 @@ class BoardEval {
   factory BoardEval.from(Board b, {WildMode wildMode = WildMode.none}) {
     if (wildMode == WildMode.deuces) {
       final bottom = HandEvaluator.evaluate5DeucesWild(b.bottom);
+      final bestMiddle = HandEvaluator.evaluate5DeucesWild(b.middle);
+      final bestTop = HandEvaluator.evaluate3DeucesWild(b.top);
       // Optimize middle with context-awareness to avoid foul
       final middle = _optimizeMiddleDeucesWild(b.middle, bottom);
       // Optimize top with context-awareness to avoid foul
       final top = _optimizeTopDeucesWild(b.top, middle);
-      return BoardEval(top: top, middle: middle, bottom: bottom);
+      final optimized = BoardEval(top: top, middle: middle, bottom: bottom);
+      if (_isFoul(optimized)) {
+        return BoardEval(top: bestTop, middle: bestMiddle, bottom: bottom);
+      }
+      return optimized;
     }
     if (wildMode == WildMode.joker) {
       final bottom = HandEvaluator.evaluate5JokerWild(b.bottom);
+      final bestMiddle = HandEvaluator.evaluate5JokerWild(b.middle);
+      final bestTop = HandEvaluator.evaluate3JokerWild(b.top);
       // Optimize middle with context-awareness to avoid foul
       final middle = _optimizeMiddleJokerWild(b.middle, bottom);
       // Optimize top with context-awareness to avoid foul
       final top = _optimizeTopJokerWild(b.top, middle);
-      return BoardEval(top: top, middle: middle, bottom: bottom);
+      final optimized = BoardEval(top: top, middle: middle, bottom: bottom);
+      if (_isFoul(optimized)) {
+        return BoardEval(top: bestTop, middle: bestMiddle, bottom: bottom);
+      }
+      return optimized;
     }
     return BoardEval(
       top: HandEvaluator.evaluate3(b.top),
@@ -73,6 +85,12 @@ class BoardEval {
   static bool _wouldCauseFoul(Hand3Rank top, Hand5Rank middle) {
     final topAs5 = _asFive(top);
     return _compare5(middle, topAs5) < 0; // middle < top means foul
+  }
+
+  static bool _isFoul(BoardEval e) {
+    final okBottom = _compare5(e.bottom, e.middle) >= 0;
+    final okMiddle = _compare5(e.middle, _asFive(e.top)) >= 0;
+    return !(okBottom && okMiddle);
   }
 
   static Hand5Rank _asFive(Hand3Rank r) {

--- a/test/foul_checker_test.dart
+++ b/test/foul_checker_test.dart
@@ -3,6 +3,7 @@ import 'package:test/test.dart';
 import 'package:ofc_app_core/features/game/domain/board.dart';
 import 'package:ofc_app_core/features/game/domain/foul_checker.dart';
 import 'package:ofc_app_core/features/game/domain/game_options.dart';
+import 'package:ofc_app_core/features/game/domain/hand_category3.dart';
 import 'package:ofc_app_core/features/game/domain/hand_category5.dart';
 import 'helpers.dart';
 
@@ -83,6 +84,23 @@ void main() {
       // Middle should be optimized to Two Pair (7766) instead of Four 7s
       expect(e.middle.category, Hand5Category.twoPair);
       expect(FoulChecker.isFoul(e), isFalse);
+    });
+
+    test('Deuces wild still shows best hands when foul is unavoidable', () {
+      // Top: 2s 2h 5h -> best is trips 5s (wild)
+      // Middle: 6h 6c 4h 2c 6s -> best is four of a kind 6s (wild)
+      // Bottom: Ts Qc Jd Qh Tc -> two pair (QQ + TT)
+      final b = Board(
+        top: [c('2s'), c('2h'), c('5h')],
+        middle: [c('6h'), c('6c'), c('4h'), c('2c'), c('6s')],
+        bottom: [c('Ts'), c('Qc'), c('Jd'), c('Qh'), c('Tc')],
+      );
+      final e = BoardEval.from(b, wildMode: WildMode.deuces);
+      expect(FoulChecker.isFoul(e), isTrue);
+      expect(e.top.category, Hand3Category.threeOfAKind);
+      expect(e.top.tiebreakers.first, 5);
+      expect(e.middle.category, Hand5Category.fourOfAKind);
+      expect(e.middle.tiebreakers.first, 6);
     });
   });
 


### PR DESCRIPTION
## Summary
- show best wild evaluations when optimized hands still foul (issue #27)
- add regression test for the deuces-wild foul scenario

## Changes
- fall back to best wild evals when optimized board remains foul
- add issue #27 hand setup test

## Test Plan
- `dart test test/foul_checker_test.dart` (not run: dart is unavailable in this environment)

## Notes
- issue #27 reproduction uses the provided card setup